### PR TITLE
fix: use `.error(..)` for better error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,12 +22,12 @@ const plugin = (options = {}) => {
   return {
     postcssPlugin: "postcss-var-func-fallback",
     Declaration(decl, { result }) {
-      function failOrWarn(text) {
+      function failOrWarn(text, name) {
         if (opts.treatErrorsAsWarnings) {
           decl.warn(result, text);
           return;
         }
-        throw Error(text);
+        throw decl.error(text, { word: name });
       }
 
       if (decl[processed] || !decl.value.includes("var(--")) {
@@ -45,14 +45,14 @@ const plugin = (options = {}) => {
         const varName = node.nodes[0].value;
 
         if (node.nodes.length > 1) {
-          failOrWarn(`Fallback value already provided for variable ${varName}`);
+          failOrWarn(`Fallback value already provided for variable ${varName}`, varName);
           return;
         }
 
         const varValue = opts.variables[varName];
 
         if (!varValue) {
-          failOrWarn(`Fallback value not found for variable ${varName}`);
+          failOrWarn(`Fallback value not found for variable ${varName}`, varName);
           return;
         }
 


### PR DESCRIPTION
This is what is recommended by the [plugin guidelines](https://github.com/postcss/postcss/blob/main/docs/guidelines/plugin.md#41-use-nodeerror-on-css-relevant-errors).

Without this you get a non-specific generic `Error` with only the error message. PostCSS does augment it with the `postcssNode` property but it isn't very helpful.

Having an uncaught exception when using this plugin spews out thousands on lines:

```
Error: Fallback value not found for variable --foobar
    at /path/to/projectsrc/style.scss:1325:5
    at failOrWarn (/path/to/project/node_modules/postcss-var-func-fallback/index.js:31:15)
    at /path/to/project/node_modules/postcss-var-func-fallback/index.js:56:11
    at walk (/path/to/project/node_modules/postcss-value-parser/lib/walk.js:7:16)
    at ValueParser.walk (/path/to/project/node_modules/postcss-value-parser/lib/index.js:18:3)
    at Declaration (/path/to/project/node_modules/postcss-var-func-fallback/index.js:41:19)
    at LazyResult.visitTick (/path/to/project/node_modules/postcss/lib/lazy-result.js:447:16)
    at LazyResult.runAsync (/path/to/project/node_modules/postcss/lib/lazy-result.js:275:30)
    at async postprocess (file:///path/to/projectbuild.mjs:77:12)
    at async compileSass (file:///path/to/projectbuild.mjs:123:25)
    at async file:///path/to/projectbuild.mjs:156:5 {
  postcssNode: <ref *1> Declaration {
    raws: { before: '\n    ', between: ': ' },
    type: 'decl',
    parent: <ref *3> Rule {
      raws: { before: '\n  ', between: ' ', semicolon: true, after: '\n  ' },
      type: 'rule',
      nodes: [ [Circular *1] ],
      parent: <ref *2> AtRule {
        raws: {
          before: '\n',
          between: ' ',
--- and about 2000 more lines here ---
```

After this bugfix you still get about the same amount of output for an uncaught exception, more actually, but it is more useful:

```diff
-Error: Fallback value not found for variable --foobar
+CssSyntaxError: /path/to/project/src/foo/bar/_baz.scss:12:8: Fallback value not found for variable --foobar
```

So for starters the error message now includes the original (sourcemap supported!) filename, line and column but the error itself is also easier to handle:

```ts
console.log(err instanceof postcss.CssSyntaxError); /// true
console.log(err.name); /// "CssSyntaxError"
```

The `err` object includes properties such as:

* `file` - original filename
* `source` - original source code (that is, the content of the file, not the entire processed source)
* line start/end - relative to the original source 
* column start/end - relative to the original source

etc...

My catch may now look something like this:

```ts
try {
    /* call postcss */
} catch (err) {
    if (err instanceof postcss.CssSyntaxError) {
        console.error(`${err.file}:${err.line}:${err.column}: ${err.reason}`);
        process.exitCode = 1;
    } else {
        throw err;
    }
}
```

or to make to very overkill:

```ts
        const output = codeFrameColumns(
            err.source,
            {
                start: { line: err.line, column: err.column },
                end: { line: err.endLine, column: err.endColumn },
            },
            {
                message: err.reason,
            },
        );
        console.error(output);
```

to turn the printed output from the error into:

```
    10 |
    11 |     &:last-child {
  > 12 |         margin-right: var(--foobar);
       |        ^ Fallback value not found for variable --foobar
    13 |     }
    14 | }
    15 |
```

:partying_face: Okay the reported location could use some tweaking but way better than before.